### PR TITLE
refactor: move jwt/v5 related code to the helpers

### DIFF
--- a/cmd/cservice-api/main.go
+++ b/cmd/cservice-api/main.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/undernetirc/cservice-api/internal/globals"
 
-	"github.com/golang-jwt/jwt/v5"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/jackc/pgx/v4/pgxpool"
 	echojwt "github.com/labstack/echo-jwt/v4"
@@ -169,13 +168,7 @@ func run() error {
 	}
 
 	// JWT restricted API routes
-	jwtConfig := echojwt.Config{
-		SigningMethod: config.ServiceJWTSigningMethod.GetString(),
-		SigningKey:    helper.GetJWTPublicKey(),
-		NewClaimsFunc: func(c echo.Context) jwt.Claims {
-			return new(helper.JwtClaims)
-		},
-	}
+	jwtConfig := helper.GetEchoJWTConfig()
 
 	prefixV1 := strings.Join([]string{config.ServiceApiPrefix.GetString(), "v1"}, "/")
 

--- a/controllers/authentication_test.go
+++ b/controllers/authentication_test.go
@@ -881,6 +881,13 @@ func TestAuthenticationController_RefreshToken(t *testing.T) {
 		e.ServeHTTP(w, r)
 		resp := w.Result()
 
+		cErr := new(customError)
+		dec := json.NewDecoder(resp.Body)
+		if err := dec.Decode(&cErr); err != nil {
+			t.Error("error decoding", err)
+		}
+
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, "refresh token expired", cErr.Message)
 	})
 }


### PR DESCRIPTION
## Summary
Avoid having jwt/v5 import spread out across multiple files. Keep it within the jwt helpers.