### PR TITLE
fix: block suspended users from authenticating (closes #37)

### DIFF
--- a/controllers/authentication.go
+++ b/controllers/authentication.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -48,6 +49,33 @@ func (ctr *AuthenticationController) now() time.Time {
 		return time.Now()
 	}
 	return ctr.clock()
+}
+
+// suspendedAccountMessage is the client-facing text for a globally suspended
+// account. Kept identical across every path so the response does not reveal
+// which check rejected the caller.
+const suspendedAccountMessage = "Your account is suspended. Please contact CService support for assistance."
+
+// rejectIfSuspended reports whether the account carries the global suspend
+// flag and, when it does, logs the attempt and writes a 403 to c. The caller
+// must stop and write no further response.
+//
+// Every path that mints a token has to call this, not just Login. An access
+// token lives 5 minutes but a refresh token lives 7 days, and RefreshToken
+// issues a fresh refresh token on each call -- so with a login-only check an
+// already-authenticated user rolls their session indefinitely and suspension
+// never takes effect until they stop refreshing. VerifyFactor is likewise
+// reachable with a state token minted just before the suspension landed.
+func rejectIfSuspended(c echo.Context, logger *slog.Logger, user *models.GetUserRow, path string) bool {
+	if !user.Flags.HasFlag(flags.UserGlobalSuspend) {
+		return false
+	}
+	logger.Warn("Blocked suspended account",
+		"username", user.Username,
+		"userID", user.ID,
+		"path", path)
+	_ = apierrors.HandleForbiddenError(c, suspendedAccountMessage)
+	return true
 }
 
 // NewAuthenticationController returns a new AuthenticationController
@@ -104,6 +132,7 @@ type loginStateResponse struct {
 // @Param data body loginRequest true "Login request"
 // @Success 200 {object} LoginResponse
 // @Failure 401 {object} errors.ErrorResponse "Invalid username or password"
+// @Failure 403 {object} errors.ErrorResponse "Account is suspended"
 // @Router /login [post]
 func (ctr *AuthenticationController) Login(c echo.Context) error {
 	logger := helper.GetRequestLogger(c)
@@ -164,6 +193,12 @@ func (ctr *AuthenticationController) Login(c echo.Context) error {
 			}
 
 			tc.AddAttr("auth.password_valid", true)
+
+			if rejectIfSuspended(c, logger, &user, "login") {
+				tc.AddAttr("auth.account_suspended", true)
+				return fmt.Errorf("authentication_failed: account suspended")
+			}
+
 			tc.MarkSuccess()
 			return nil
 		}).
@@ -371,6 +406,12 @@ func (ctr *AuthenticationController) RefreshToken(c echo.Context) error {
 			return apierrors.HandleUnauthorizedError(c, "Invalid user")
 		}
 
+		// Checked before the refresh token is consumed: a suspended account
+		// must not be able to trade a live refresh token for a new pair.
+		if rejectIfSuspended(c, logger, &user, "refresh_token") {
+			return nil
+		}
+
 		deletedRows, err := ctr.deleteRefreshToken(ctx, userID, refreshUUID, false)
 		if err != nil || deletedRows == 0 {
 			logger.Error("Failed to delete refresh token",
@@ -530,6 +571,12 @@ func (ctr *AuthenticationController) VerifyFactor(c echo.Context) error {
 			"userID", userID,
 			"error", err.Error())
 		return apierrors.HandleNotFoundError(c, "User")
+	}
+
+	// A state token minted before the suspension landed is still valid here,
+	// so completing 2FA would otherwise hand out a full token pair.
+	if rejectIfSuspended(c, logger, &user, "verify_factor") {
+		return nil
 	}
 
 	if user.Flags.HasFlag(flags.UserTotpEnabled) && user.TotpKey.String != "" {

--- a/controllers/authentication_test.go
+++ b/controllers/authentication_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/undernetirc/cservice-api/db/mocks"
 	"github.com/undernetirc/cservice-api/db/types/flags"
@@ -173,6 +174,64 @@ func TestAuthenticationController_Login(t *testing.T) {
 
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
+
+	suspendedCases := []struct {
+		name          string
+		userFlags     flags.User
+		totpKey       string
+		wantBodyHas   string
+		wantBodyLacks string
+	}{
+		{
+			name:        "suspended user (no 2FA) is blocked with 403",
+			userFlags:   flags.UserGlobalSuspend,
+			wantBodyHas: "suspended",
+		},
+		{
+			name:          "suspended user with 2FA is blocked before MFA challenge",
+			userFlags:     flags.UserGlobalSuspend | flags.UserTotpEnabled,
+			totpKey:       seed,
+			wantBodyLacks: "MFA_REQUIRED",
+		},
+	}
+	for _, tt := range suspendedCases {
+		t.Run(tt.name, func(t *testing.T) {
+			db := mocks.NewQuerier(t)
+			db.On("GetUser", mock.Anything, models.GetUserParams{Username: "Admin"}).
+				Return(models.GetUserRow{
+					ID:       1,
+					Username: "Admin",
+					Password: "xEDi1V791f7bddc526de7e3b0602d0b2993ce21d",
+					Flags:    tt.userFlags,
+					TotpKey:  pgtype.Text{String: tt.totpKey},
+				}, nil).Once()
+
+			rdb, _ := redismock.NewClientMock()
+			checks.InitUser(context.Background(), db)
+			authController := NewAuthenticationController(db, rdb, nil)
+
+			e := echo.New()
+			e.Validator = helper.NewValidator()
+			e.POST("/login", authController.Login)
+
+			body := bytes.NewBufferString(`{"username": "Admin", "password": "temPass2020@"}`)
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest("POST", "/login", body)
+			r.Header.Set("Content-Type", "application/json")
+
+			e.ServeHTTP(w, r)
+			resp := w.Result()
+
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+			assert.Empty(t, w.Header().Get("Set-Cookie"))
+			if tt.wantBodyHas != "" {
+				assert.Contains(t, w.Body.String(), tt.wantBodyHas)
+			}
+			if tt.wantBodyLacks != "" {
+				assert.NotContains(t, w.Body.String(), tt.wantBodyLacks)
+			}
+		})
+	}
 
 	t.Run("OTP enabled, should get MFA_REQUIRED status", func(t *testing.T) {
 		db := mocks.NewQuerier(t)
@@ -1564,4 +1623,105 @@ func TestAuthenticationController_ResetPassword(t *testing.T) {
 			db.AssertExpectations(t)
 		})
 	}
+}
+
+// Regression for the suspension bypass: the global suspend flag was enforced
+// only in Login, so an already-authenticated user kept full access after being
+// suspended. RefreshToken re-issues a 7-day refresh token on every call, so a
+// live client rolled its session indefinitely; VerifyFactor completed any 2FA
+// login whose state token was minted before the suspension landed. Both paths
+// returned 200 before this fix.
+func TestAuthenticationController_SuspendedAccountCannotMintTokens(t *testing.T) {
+	config.DefaultConfig()
+
+	t.Run("refresh token path", func(t *testing.T) {
+		claims := new(helper.JwtClaims)
+		claims.UserID = 1
+		claims.Username = "Admin"
+		n := time.Now()
+		tokens, _ := helper.GenerateToken(claims, n)
+		timeMock := func() time.Time { return n }
+
+		db := mocks.NewQuerier(t)
+		db.On("GetUser", mock.Anything, models.GetUserParams{ID: int32(1)}).
+			Return(models.GetUserRow{
+				ID:       1,
+				Username: "Admin",
+				Flags:    flags.UserGlobalSuspend,
+			}, nil).Once()
+
+		rdb, rmock := redismock.NewClientMock()
+		rt := time.Unix(tokens.RtExpires.Unix(), 0)
+		key := fmt.Sprintf("user:%d:rt:%s", claims.UserID, tokens.RefreshUUID)
+		rmock.ExpectSet(key, strconv.Itoa(int(claims.UserID)), rt.Sub(n)).SetVal("1")
+
+		checks.InitUser(context.Background(), db)
+		authController := NewAuthenticationController(db, rdb, timeMock)
+		require.NoError(t, authController.storeRefreshToken(context.Background(), 1, tokens))
+
+		e := echo.New()
+		e.Validator = helper.NewValidator()
+		e.POST("/token/refresh", authController.RefreshToken)
+
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("POST", "/token/refresh", nil)
+		r.Header.Add("Content-Type", "application/json")
+		r.Header.Add("Cookie", "refresh_token="+tokens.RefreshToken)
+
+		e.ServeHTTP(w, r)
+		resp := w.Result()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Contains(t, w.Body.String(), "suspended")
+
+		// The whole point: no fresh refresh token may be handed back, or the
+		// suspended session renews itself.
+		for _, ck := range resp.Cookies() {
+			assert.NotEqual(t, "refresh_token", ck.Name,
+				"suspended refresh must not issue a new refresh cookie")
+		}
+
+		// The refresh token is rejected before it is consumed, so no Redis
+		// delete is expected.
+		assert.NoError(t, rmock.ExpectationsWereMet())
+	})
+
+	t.Run("verify factor path", func(t *testing.T) {
+		seed := "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+		db := mocks.NewServiceInterface(t)
+		db.On("GetUser", mock.Anything, models.GetUserParams{ID: int32(1)}).
+			Return(models.GetUserRow{
+				ID:       1,
+				Username: "Admin",
+				Flags:    flags.UserGlobalSuspend | flags.UserTotpEnabled,
+				TotpKey:  pgtype.Text{String: seed},
+			}, nil).Once()
+
+		rdb, rmock := redismock.NewClientMock()
+		rmock.ExpectGet("user:mfa:state:test").SetVal("1")
+
+		authController := NewAuthenticationController(db, rdb, nil)
+
+		e := echo.New()
+		e.Validator = helper.NewValidator()
+		e.POST("/validate-otp", authController.VerifyFactor)
+
+		otp := totp.New(seed, 6, 30, 1)
+		body := bytes.NewBufferString(
+			fmt.Sprintf(`{"state_token": "test", "otp": "%s"}`, otp.Generate()),
+		)
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("POST", "/validate-otp", body)
+		r.Header.Set("Content-Type", "application/json")
+
+		e.ServeHTTP(w, r)
+		resp := w.Result()
+
+		// A valid TOTP for a suspended account must still be refused.
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Contains(t, w.Body.String(), "suspended")
+		assert.Empty(t, w.Header().Get("Set-Cookie"))
+		assert.NoError(t, rmock.ExpectationsWereMet())
+	})
 }

--- a/integration/authentication_controller_test.go
+++ b/integration/authentication_controller_test.go
@@ -9,16 +9,22 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/undernetirc/cservice-api/controllers"
+	"github.com/undernetirc/cservice-api/db/types/flags"
+	"github.com/undernetirc/cservice-api/db/types/password"
 	"github.com/undernetirc/cservice-api/internal/checks"
 	"github.com/undernetirc/cservice-api/internal/config"
 	"github.com/undernetirc/cservice-api/internal/helper"
@@ -54,4 +60,51 @@ func TestAuthController_Login(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, loginResponse.AccessToken, "access token should not be empty")
+}
+
+func TestAuthController_LoginSuspendedUser(t *testing.T) {
+	config.DefaultConfig()
+
+	service := models.NewService(db)
+	checks.InitUser(context.Background(), db)
+
+	authController := controllers.NewAuthenticationController(service, rdb, nil)
+
+	e := echo.New()
+	e.Validator = helper.NewValidator()
+	e.POST("/", authController.Login)
+
+	pwd := password.Password("")
+	require.NoError(t, pwd.Set("SuspendedPass1!"))
+
+	nanoSuffix := fmt.Sprintf("%d", time.Now().UnixNano()%1000000)
+	username := "susp" + nanoSuffix
+	created, err := service.CreateUser(ctx, models.CreateUserParams{
+		Username:         username,
+		Password:         pwd,
+		Email:            pgtype.Text{String: username + "@example.com", Valid: true},
+		Flags:            flags.UserGlobalSuspend,
+		LastUpdated:      int32(time.Now().Unix()),
+		LastUpdatedBy:    pgtype.Text{String: "test", Valid: true},
+		LanguageID:       pgtype.Int4{Int32: 1, Valid: true},
+		QuestionID:       pgtype.Int2{Int16: 1, Valid: true},
+		Verificationdata: pgtype.Text{String: "test_data", Valid: true},
+		SignupTs:         pgtype.Int4{Int32: int32(time.Now().Unix()), Valid: true},
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	body := bytes.NewBufferString(fmt.Sprintf(
+		`{"username": %q, "password": "SuspendedPass1!"}`, username,
+	))
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/", body)
+	r.Header.Set("Content-Type", "application/json")
+
+	e.ServeHTTP(w, r)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, w.Body.String(), "suspended")
+	assert.Empty(t, w.Header().Get("Set-Cookie"))
 }

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1446,6 +1446,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
+                    },
+                    "403": {
+                        "description": "Account is suspended",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -1440,6 +1440,12 @@
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
+                    },
+                    "403": {
+                        "description": "Account is suspended",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -1808,6 +1808,10 @@ paths:
           description: Invalid username or password
           schema:
             $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Account is suspended
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
       summary: Login
       tags:
       - auth


### PR DESCRIPTION
A user carrying the global suspend flag could still authenticate. Login
did not check the flag; and even with that check, the other token-minting
paths did not -- so an already-authenticated user kept full access after
being suspended. RefreshToken re-issues a 7-day refresh token on every
call, letting a live client roll its session indefinitely, and
VerifyFactor completed any 2FA login whose state token was minted before
the suspension landed.

Add a rejectIfSuspended helper and call it on every path that mints a
token:
- Login: after password validation, before the MFA challenge, so a
  suspended 2FA user is refused without leaking an MFA_REQUIRED state
  token.
- RefreshToken: after the user is loaded, before the refresh token is
  consumed, so no new token pair is issued.
- VerifyFactor: after the user is loaded, before 2FA completes.

All three return 403 with an identical message so the response does not
reveal which check fired. Document the 403 on the Login endpoint and
regenerate the Swagger definitions.

Tests: Login suspended cases (403, no Set-Cookie, no MFA_REQUIRED leak)
as a struct table; unit coverage of the RefreshToken and VerifyFactor
paths (TestAuthenticationController_SuspendedAccountCannotMintTokens);
and an integration test that creates a suspended user and asserts Login
returns 403.
