### PR TITLE
chore: bump Go toolchain to 1.25.12 to clear reachable stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/undernetirc/cservice-api
 
-go 1.25.6
+go 1.25.12
 
 require (
 	github.com/go-jose/go-jose/v3 v3.0.5


### PR DESCRIPTION
govulncheck reports 17 vulnerabilities in the Go standard library that
this code actually reaches -- across crypto/tls, html/template, net/http,
net/url, net/mail, net/textproto, net and os -- each fixed in a Go point
release between 1.25.7 and 1.25.12. The module was pinned to go 1.25.6.

Bump the go directive to 1.25.12, the lowest release carrying every cited
fix. After the bump govulncheck reports 0 reachable vulnerabilities.
Build and unit tests (config, helper, controllers, db) pass under 1.25.12.
