### PR TITLE
test: enable dormant DB integration tests against testcontainers

### DIFF
--- a/integration/database_integration_test.go
+++ b/integration/database_integration_test.go
@@ -7,8 +7,9 @@ package integration
 
 import (
 	"context"
-	"database/sql"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -19,22 +20,12 @@ import (
 	"github.com/undernetirc/cservice-api/models"
 )
 
-var queries *models.Queries
-
-func setupTestDatabase() (*sql.DB, error) {
-	// Skip database setup in this version - would need actual database connection
-	return nil, nil
-}
-
-// TestDatabaseIntegration tests comprehensive database operations
+// TestDatabaseIntegration exercises the sqlc-generated queries against the
+// real Postgres provisioned by main_test.go's testcontainers setup.
 func TestDatabaseIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-
-	// Mock database queries for now
-	// In real integration tests, this would be a real database connection
-	t.Skip("Integration tests require actual database setup")
 
 	t.Run("User Operations", func(t *testing.T) {
 		testUserOperations(t)
@@ -56,73 +47,66 @@ func TestDatabaseIntegration(t *testing.T) {
 func testUserOperations(t *testing.T) {
 	ctx := context.Background()
 
-	// Test creating a new user (using available CreateUser method)
+	// Fresh user per run to avoid uniqueness conflicts.
+	suffix := strconv.FormatInt(time.Now().UnixNano()%1000000, 10)
 	createParams := models.CreateUserParams{
-		Username: "integration_test_user",
-		Email:    pgtype.Text{String: "integration@test.com", Valid: true},
-		Password: password.Password("hashed_password"),
-		Flags:    0,
+		Username:         "itst_" + suffix,
+		Password:         password.Password("hashed_password"),
+		Email:            pgtype.Text{String: "itst_" + suffix + "@test.com", Valid: true},
+		Flags:            0,
+		LastUpdated:      int32(time.Now().Unix()),
+		LastUpdatedBy:    pgtype.Text{String: "test", Valid: true},
+		LanguageID:       pgtype.Int4{Int32: 1, Valid: true},
+		QuestionID:       pgtype.Int2{Int16: 1, Valid: true},
+		Verificationdata: pgtype.Text{String: "test_data", Valid: true},
+		SignupTs:         pgtype.Int4{Int32: int32(time.Now().Unix()), Valid: true},
 	}
 
-	user, err := queries.CreateUser(ctx, createParams)
+	user, err := db.CreateUser(ctx, createParams)
 	require.NoError(t, err)
 	assert.NotZero(t, user.ID)
 	assert.Equal(t, createParams.Username, user.Username)
 	assert.Equal(t, createParams.Email.String, user.Email.String)
 
-	// Test getting the user by ID
-	retrievedUser, err := queries.GetUser(ctx, models.GetUserParams{ID: user.ID})
+	retrievedUser, err := db.GetUser(ctx, models.GetUserParams{ID: user.ID})
 	require.NoError(t, err)
 	assert.Equal(t, user.ID, retrievedUser.ID)
 	assert.Equal(t, user.Username, retrievedUser.Username)
 
-	// Test getting user by username
-	userByUsername, err := queries.GetUser(ctx, models.GetUserParams{Username: user.Username})
+	userByUsername, err := db.GetUser(ctx, models.GetUserParams{Username: user.Username})
 	require.NoError(t, err)
 	assert.Equal(t, user.ID, userByUsername.ID)
 
-	// Test updating user flags
-	err = queries.UpdateUserFlags(ctx, models.UpdateUserFlagsParams{
+	err = db.UpdateUserFlags(ctx, models.UpdateUserFlagsParams{
 		ID:    user.ID,
 		Flags: flags.UserTotpEnabled,
 	})
 	require.NoError(t, err)
 
-	// Test getting user with updated flags
-	getParams := models.GetUserParams{ID: user.ID}
-	updatedUser, err := queries.GetUser(ctx, getParams)
+	updatedUser, err := db.GetUser(ctx, models.GetUserParams{ID: user.ID})
 	require.NoError(t, err)
-	assert.True(t, updatedUser.Flags&flags.UserTotpEnabled != 0)
-
-	// Test search functionality (using available SearchChannels as example)
-	// Note: There's no SearchUsers method, so this test would need modification
-	t.Log("User search would need SearchUsers method to be implemented")
-
-	// Cleanup - Note: There's no DeleteUser method available
-	t.Log("User cleanup would need DeleteUser method to be implemented")
+	assert.True(t, updatedUser.Flags.HasFlag(flags.UserTotpEnabled))
 }
 
 func testChannelOperations(t *testing.T) {
 	ctx := context.Background()
 
-	// Test getting channel by ID (using available method)
-	channelID := int32(1) // Assuming test data exists
-	channel, err := queries.GetChannelByID(ctx, channelID)
+	// Rely on the seed data provided by the migration fixtures.
+	channelID := int32(1)
+	channel, err := db.GetChannelByID(ctx, channelID)
 	if err != nil {
-		t.Skip("No test channel data available")
+		t.Skip("No seeded channel with ID 1 available")
 		return
 	}
 
 	assert.NotZero(t, channel.ID)
 	assert.NotEmpty(t, channel.Name)
 
-	// Test getting channel by name
-	channelByName, err := queries.GetChannelByName(ctx, channel.Name)
+	channelByName, err := db.GetChannelByName(ctx, channel.Name)
 	require.NoError(t, err)
 	assert.Equal(t, channel.ID, channelByName.ID)
 
-	// Test channel search
-	searchResult, err := queries.SearchChannels(ctx, models.SearchChannelsParams{
+	searchResult, err := db.SearchChannels(ctx, models.SearchChannelsParams{
 		Name:   "%" + channel.Name + "%",
 		Limit:  10,
 		Offset: 0,
@@ -130,143 +114,83 @@ func testChannelOperations(t *testing.T) {
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(searchResult), 1)
 
-	// Test checking if channel exists (returns channel data, not boolean)
-	existsResult, err := queries.CheckChannelExists(ctx, channel.ID)
+	existsResult, err := db.CheckChannelExists(ctx, channel.ID)
 	require.NoError(t, err)
 	assert.Equal(t, channel.ID, existsResult.ID)
-
-	// Note: Channel creation, update, and deletion methods are not available
-	t.Log("Channel creation/update/deletion would need corresponding methods")
 }
 
 func testChannelMembershipOperations(t *testing.T) {
 	ctx := context.Background()
 
-	// Test with sample data (assuming user 1 and channel 1 exist)
 	userID := int32(1)
 	channelID := int32(1)
 
-	// Test checking if member exists (returns member data, not boolean)
-	memberData, err := queries.CheckChannelMemberExists(ctx, channelID, userID)
+	memberData, err := db.CheckChannelMemberExists(ctx, channelID, userID)
 	if err != nil {
-		t.Skip("No test membership data available")
+		t.Skip("No seeded membership for user 1 / channel 1 available")
 		return
 	}
 
-	// Test getting user access level
-	access, err := queries.GetChannelUserAccess(ctx, channelID, userID)
+	access, err := db.GetChannelUserAccess(ctx, channelID, userID)
 	if err == nil {
 		assert.NotZero(t, access.Access)
 	}
 
-	// Test adding a channel member if one doesn't exist
-	// Note: AddChannelMemberParams uses Access field, not AccessLevel, and AddedBy is pgtype.Text
-	if memberData.ChannelID == 0 { // Member doesn't exist
-		addParams := models.AddChannelMemberParams{
+	if memberData.ChannelID == 0 {
+		_, err = db.AddChannelMember(ctx, models.AddChannelMemberParams{
 			ChannelID: channelID,
 			UserID:    userID,
 			Access:    500,
 			AddedBy:   pgtype.Text{String: "system", Valid: true},
-		}
-
-		_, err = queries.AddChannelMember(ctx, addParams)
+		})
 		require.NoError(t, err)
 
-		// Verify member was added
-		newMemberData, err := queries.CheckChannelMemberExists(ctx, channelID, userID)
+		newMemberData, err := db.CheckChannelMemberExists(ctx, channelID, userID)
 		require.NoError(t, err)
 		assert.NotZero(t, newMemberData.ChannelID)
 	}
 
-	// Test getting members by access level
-	members, err := queries.GetChannelMembersByAccessLevel(ctx, channelID, 500)
+	members, err := db.GetChannelMembersByAccessLevel(ctx, channelID, 500)
 	require.NoError(t, err)
 	t.Logf("Found %d members with access level 500", len(members))
 
-	// Test counting channel owners
-	ownerCount, err := queries.CountChannelOwners(ctx, channelID)
+	ownerCount, err := db.CountChannelOwners(ctx, channelID)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, ownerCount, int64(0))
-
-	t.Log("Member removal would need RemoveChannelMember method with correct parameters")
 }
 
 func testComplexQueries(t *testing.T) {
 	ctx := context.Background()
 
-	// Test user channel memberships
-	userID := int32(1) // Assuming test user exists
-	memberships, err := queries.GetUserChannelMemberships(ctx, userID)
+	userID := int32(1)
+	memberships, err := db.GetUserChannelMemberships(ctx, userID)
 	if err != nil {
-		t.Skip("No user membership data available")
+		t.Skip("No user membership data available for user 1")
 		return
 	}
 
 	t.Logf("User %d has %d channel memberships", userID, len(memberships))
 
-	// Test user channels
-	channels, err := queries.GetUserChannels(ctx, userID)
+	channels, err := db.GetUserChannels(ctx, userID)
 	require.NoError(t, err)
 	t.Logf("User %d is in %d channels", userID, len(channels))
 
-	// Test admin level check
-	adminLevel, err := queries.GetAdminLevel(ctx, userID)
-	if err == nil {
-		t.Logf("User %d admin level: %d", userID, adminLevel.Access)
+	if _, err := db.GetAdminLevel(ctx, userID); err == nil {
+		t.Logf("User %d has an admin-level row", userID)
 	}
 
-	// Test channel details
 	if len(channels) > 0 {
-		channelID := channels[0].ChannelID
-		details, err := queries.GetChannelDetails(ctx, channelID)
+		details, err := db.GetChannelDetails(ctx, channels[0].ChannelID)
 		require.NoError(t, err)
 		assert.NotZero(t, details.ID)
 		assert.NotEmpty(t, details.Name)
 	}
 }
 
-// TestTransactionIntegrity tests database transaction handling
-func TestTransactionIntegrity(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping transaction integration tests in short mode")
-	}
-
-	t.Skip("Transaction tests require actual database setup with transaction support")
-
-	// This would test transaction rollback scenarios
-	t.Log("Transaction integrity tests would be implemented here")
-}
-
-// TestConcurrentOperations tests handling of concurrent database operations
-func TestConcurrentOperations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping concurrent operation tests in short mode")
-	}
-
-	t.Skip("Concurrent tests require actual database setup")
-
-	// This would test concurrent database operations
-	t.Log("Concurrent operation tests would be implemented here")
-}
-
-func TestPerformanceQueries(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping performance tests in short mode")
-	}
-
-	t.Skip("Performance tests require actual database setup with test data")
-
-	// This would benchmark database query performance
-	t.Log("Performance tests would measure query execution times")
-}
-
-// Helper function for benchmark testing
 func BenchmarkChannelSearch(b *testing.B) {
 	if testing.Short() {
 		b.Skip("Skipping benchmark in short mode")
 	}
-
-	b.Skip("Benchmark requires actual database setup")
 
 	ctx := context.Background()
 	searchParams := models.SearchChannelsParams{
@@ -277,8 +201,7 @@ func BenchmarkChannelSearch(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := queries.SearchChannels(ctx, searchParams)
-		if err != nil {
+		if _, err := db.SearchChannels(ctx, searchParams); err != nil {
 			b.Fatalf("Search failed: %v", err)
 		}
 	}
@@ -289,15 +212,12 @@ func BenchmarkUserChannelMemberships(b *testing.B) {
 		b.Skip("Skipping benchmark in short mode")
 	}
 
-	b.Skip("Benchmark requires actual database setup")
-
 	ctx := context.Background()
 	userID := int32(1)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := queries.GetUserChannelMemberships(ctx, userID)
-		if err != nil {
+		if _, err := db.GetUserChannelMemberships(ctx, userID); err != nil {
 			b.Fatalf("Query failed: %v", err)
 		}
 	}


### PR DESCRIPTION
integration/database_integration_test.go was written before the
testcontainers-backed integration harness (main_test.go) landed and
was never re-enabled. Every top-level test and benchmark starts with
an unconditional t.Skip("... requires actual database setup"), while
main_test.go already provisions a real Postgres container and exposes
it via the package-level db (*models.Queries) and dbPool.

Wire the tests to the existing harness, drop the unconditional skips,
and delete three pure-placeholder tests whose bodies were just t.Log
("would be implemented here"): TestTransactionIntegrity,
TestConcurrentOperations, TestPerformanceQueries. They were dead
scaffolding, not tests.

Also:
- Remove the unused local queries *models.Queries var and its stub
  setupTestDatabase helper; database/sql import goes with them.
- testUserOperations now creates a per-run unique user with a valid
  username length and all required fields (language_id, question_id,
  verificationdata, signup_ts, last_updated_by), matching the pattern
  used in manager_change_test.go's setupTestChannelAndUser.
- testChannelOperations / testChannelMembershipOperations /
  testComplexQueries keep their defensive t.Skip guards for the
  seeded-data cases, which is the correct behavior when running
  against a clean container.
- BenchmarkChannelSearch and BenchmarkUserChannelMemberships lose
  their unconditional skips but keep the short-mode guard.

Net effect: TestDatabaseIntegration now runs 4 subtests
(User/Channel/Membership/Complex) against the real Postgres, adding
integration coverage to the sqlc-generated models package that
previously had 0% unit coverage.

