### PR TITLE
fix: prevent panic when confirmation token is shorter than 8 chars

### DIFF
--- a/controllers/channel.go
+++ b/controllers/channel.go
@@ -1954,7 +1954,7 @@ func (ctr *ChannelController) ConfirmManagerChange(c echo.Context) error {
 
 	logger.Info("Processing manager change confirmation",
 		"channelID", channelID,
-		"token", token[:8]+"...")
+		"token", token[:min(len(token), 8)]+"...")
 
 	err = ctr.s.CleanupExpiredManagerChangeRequests(ctx)
 	if err != nil {
@@ -1972,7 +1972,7 @@ func (ctr *ChannelController) ConfirmManagerChange(c echo.Context) error {
 	if err != nil {
 		logger.Warn("Invalid or expired confirmation token",
 			"channelID", channelID,
-			"token", token[:8]+"...",
+			"token", token[:min(len(token), 8)]+"...",
 			"error", err.Error())
 		return apierrors.HandleBadRequestError(c, "Invalid or expired confirmation token")
 	}
@@ -1981,7 +1981,7 @@ func (ctr *ChannelController) ConfirmManagerChange(c echo.Context) error {
 		logger.Warn("Channel ID mismatch in confirmation",
 			"requestChannelID", request.ChannelID,
 			"urlChannelID", channelID,
-			"token", token[:8]+"...")
+			"token", token[:min(len(token), 8)]+"...")
 		return apierrors.HandleBadRequestError(c, "Confirmation link not valid for this channel")
 	}
 
@@ -1989,7 +1989,7 @@ func (ctr *ChannelController) ConfirmManagerChange(c echo.Context) error {
 	if err != nil {
 		logger.Error("Failed to confirm manager change request",
 			"channelID", channelID,
-			"token", token[:8]+"...",
+			"token", token[:min(len(token), 8)]+"...",
 			"error", err.Error())
 		return apierrors.HandleDatabaseError(c, err)
 	}
@@ -1998,7 +1998,7 @@ func (ctr *ChannelController) ConfirmManagerChange(c echo.Context) error {
 		"channelID", channelID,
 		"requestID", request.ID,
 		"changeType", request.ChangeType.Int16,
-		"token", token[:8]+"...")
+		"token", token[:min(len(token), 8)]+"...")
 
 	response := ManagerChangeConfirmationResponse{
 		Status:  "success",

--- a/integration/manager_change_test.go
+++ b/integration/manager_change_test.go
@@ -515,9 +515,47 @@ func TestManagerChange_ErrorHandling(t *testing.T) {
 		assert.Contains(t, []int{http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound}, resp.StatusCode)
 	})
 
-	// Skip this test due to panic in ConfirmManagerChange - needs investigation
 	t.Run("invalid confirmation token", func(t *testing.T) {
-		t.Skip("Skipping due to panic in ConfirmManagerChange function - needs separate fix")
+		tokenCases := []struct {
+			name  string
+			token string
+		}{
+			{
+				name:  "short token (regression: would panic on token[:8] slice)",
+				token: "short",
+			},
+			{
+				name:  "long bogus token still returns 400",
+				token: "definitely-not-a-real-token-value",
+			},
+		}
+		for _, tt := range tokenCases {
+			t.Run(tt.name, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				r, _ := http.NewRequest(
+					"GET",
+					fmt.Sprintf("/channels/%d/manager-confirm?token=%s", channelID, tt.token),
+					nil,
+				)
+
+				c := e.NewContext(r, w)
+				c.SetParamNames("id")
+				c.SetParamValues(strconv.Itoa(int(channelID)))
+
+				claims := &helper.JwtClaims{
+					UserID:   userID,
+					Username: username,
+				}
+				c.Set("user", claims)
+
+				err := controller.ConfirmManagerChange(c)
+				require.NoError(t, err)
+
+				resp := w.Result()
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				assert.Contains(t, w.Body.String(), "Invalid or expired confirmation token")
+			})
+		}
 	})
 
 	t.Run("status check for nonexistent request", func(t *testing.T) {


### PR DESCRIPTION
ConfirmManagerChange logged token[:8]+"..." in five places without a
length guard, so any confirmation token shorter than 8 characters
triggered a slice-out-of-bounds panic. middleware.Recover turned that
panic into a 500, masking the intended 400 for an invalid token.

Guard every log site with token[:min(len(token), 8)] and un-skip the
integration regression test, which now drives ConfirmManagerChange with
a short token and a long bogus token through a struct table, asserting a
400 and the "Invalid or expired confirmation token" body in both cases.
