### PR TITLE
fix: propagate crypto/rand failure out of GenerateSecureToken

### DIFF
--- a/controllers/channel.go
+++ b/controllers/channel.go
@@ -1439,7 +1439,13 @@ func (ctr *ChannelController) RequestManagerChange(c echo.Context) error {
 		return apierrors.HandleDatabaseError(c, err)
 	}
 
-	confirmationToken := helper.GenerateSecureToken(64)
+	confirmationToken, err := helper.GenerateSecureToken(64)
+	if err != nil {
+		logger.Error("Failed to generate manager change confirmation token",
+			"channelID", channelID,
+			"error", err.Error())
+		return apierrors.HandleInternalError(c, err, "Failed to generate confirmation token")
+	}
 	expirationTime := time.Now().Add(6 * time.Hour)
 
 	var optDuration int32

--- a/controllers/user_register.go
+++ b/controllers/user_register.go
@@ -114,7 +114,12 @@ func (ctr *UserRegisterController) UserRegister(c echo.Context) error {
 				"pending_user.password_length":  len(req.Password),
 			})
 
-			cookie = helper.GenerateSecureToken(32)
+			var terr error
+			cookie, terr = helper.GenerateSecureToken(32)
+			if terr != nil {
+				tc.RecordError(terr)
+				return apierrors.HandleInternalError(c, terr, "Failed to generate activation token")
+			}
 			user := &models.CreatePendingUserParams{
 				Username: db.NewString(req.Username),
 				Email:    db.NewString(req.Email),

--- a/integration/user_register_test.go
+++ b/integration/user_register_test.go
@@ -33,6 +33,15 @@ import (
 	"github.com/undernetirc/cservice-api/models"
 )
 
+// randomSuffix returns n random alphanumeric characters, for building
+// identifiers that stay unique across runs against a shared database.
+func randomSuffix(t *testing.T, n int) string {
+	t.Helper()
+	s, err := helper.GenerateSecureToken(n)
+	require.NoError(t, err, "failed to generate random suffix")
+	return s
+}
+
 type userRegisterTest struct {
 	mailpitContainer testcontainers.Container
 	host             string
@@ -342,7 +351,7 @@ func TestUserRegisterController_CompleteRegistrationFlow(t *testing.T) {
 		require.NoError(t, err, "failed to clear existing emails")
 
 		// Generate unique user data with shorter username (max 12 chars)
-		username := "test" + helper.GenerateSecureToken(4) // "test" + 4 chars = 8 chars total
+		username := "test" + randomSuffix(t, 4) // "test" + 4 chars = 8 chars total
 		email := username + "@example.com"
 
 		// Step 1: Register a new user
@@ -442,7 +451,7 @@ func TestUserRegisterController_CompleteRegistrationFlow(t *testing.T) {
 		err := urt.clearMailpitMessages()
 		require.NoError(t, err)
 
-		username := "dup" + helper.GenerateSecureToken(3) // "dup" + 3 chars = 6 chars total
+		username := "dup" + randomSuffix(t, 3) // "dup" + 3 chars = 6 chars total
 		email := username + "@example.com"
 
 		registrationData := controllers.UserRegisterRequest{
@@ -720,7 +729,7 @@ func TestUserRegisterController_Integration(t *testing.T) {
 
 	t.Run("complete registration flow", func(t *testing.T) {
 		// Generate unique username to avoid conflicts
-		username := "int" + helper.GenerateSecureToken(4) // "int" + 4 chars = 7 chars total
+		username := "int" + randomSuffix(t, 4) // "int" + 4 chars = 7 chars total
 		email := username + "@example.com"
 
 		// Step 1: Register a new user
@@ -752,7 +761,7 @@ func TestUserRegisterController_Integration(t *testing.T) {
 
 			// Step 2: Try to activate with an invalid token
 			activationData := controllers.UserRegisterActivateRequest{
-				Token: "invalid-token-" + helper.GenerateSecureToken(16),
+				Token: "invalid-token-" + randomSuffix(t, 16),
 			}
 
 			bodyBytes2, _ := json.Marshal(activationData)
@@ -949,7 +958,7 @@ func TestUserRegisterController_ConcurrentDuplicateRegistration(t *testing.T) {
 		require.NoError(t, err, "failed to clear existing emails")
 
 		// Generate unique credentials for this test
-		username := "race" + helper.GenerateSecureToken(4)
+		username := "race" + randomSuffix(t, 4)
 		email := username + "@example.com"
 
 		registrationData := controllers.UserRegisterRequest{
@@ -1076,7 +1085,7 @@ func TestUserRegisterController_ConcurrentDuplicateActivation(t *testing.T) {
 		require.NoError(t, err, "failed to clear existing emails")
 
 		// Step 1: Create a pending user
-		username := "activ" + helper.GenerateSecureToken(4)
+		username := "activ" + randomSuffix(t, 4)
 		email := username + "@example.com"
 
 		registrationData := controllers.UserRegisterRequest{

--- a/internal/auth/backupcodes/generator.go
+++ b/internal/auth/backupcodes/generator.go
@@ -76,8 +76,14 @@ func (g *BackupCodeGenerator) GenerateBackupCodes() ([]string, error) {
 
 // generateSingleBackupCode generates a single backup code in the format 'abcde-12345'
 func generateSingleBackupCode() (string, error) {
-	part1 := helper.GenerateSecureToken(BackupCodePartLength)
-	part2 := helper.GenerateSecureToken(BackupCodePartLength)
+	part1, err := helper.GenerateSecureToken(BackupCodePartLength)
+	if err != nil {
+		return "", err
+	}
+	part2, err := helper.GenerateSecureToken(BackupCodePartLength)
+	if err != nil {
+		return "", err
+	}
 
 	return fmt.Sprintf("%s-%s", part1, part2), nil
 }

--- a/internal/auth/reset/manager.go
+++ b/internal/auth/reset/manager.go
@@ -54,9 +54,14 @@ func NewTokenManager(queries models.Querier, config *Config) *TokenManager {
 // CreateToken creates a new password reset token for the given user
 func (tm *TokenManager) CreateToken(ctx context.Context, userID int32) (*models.PasswordResetToken, error) {
 	// Generate secure token
-	token := helper.GenerateSecureToken(tm.config.TokenLength)
+	token, err := helper.GenerateSecureToken(tm.config.TokenLength)
+	if err != nil {
+		return nil, err
+	}
+	// GenerateSecureToken returns ("", nil) for a non-positive length, so a
+	// misconfigured TokenLength would otherwise mint an empty reset token.
 	if token == "" {
-		return nil, fmt.Errorf("failed to generate secure token")
+		return nil, fmt.Errorf("generated reset token is empty (check reset token_length config)")
 	}
 
 	// Calculate expiration time

--- a/internal/auth/reset/manager_test.go
+++ b/internal/auth/reset/manager_test.go
@@ -180,6 +180,23 @@ func TestCreateToken(t *testing.T) {
 		assert.Nil(t, result)
 		assert.ErrorContains(t, err, "failed to check active tokens")
 	})
+
+	t.Run("empty_token_is_rejected", func(t *testing.T) {
+		// A non-positive TokenLength makes GenerateSecureToken return ("", nil),
+		// which must be caught before any token row is created. No DB call is
+		// expected, so the mock is left with no expectations.
+		db := mocks.NewQuerier(t)
+		tm := NewTokenManager(db, &Config{
+			TokenLength:      0,
+			TokenLifetime:    30 * time.Minute,
+			CleanupInterval:  6 * time.Hour,
+			MaxTokensPerUser: 1,
+		})
+
+		result, err := tm.CreateToken(ctx, 100)
+		assert.Nil(t, result)
+		assert.ErrorContains(t, err, "empty")
+	})
 }
 
 func TestCreateToken_DBError(t *testing.T) {

--- a/internal/helper/token.go
+++ b/internal/helper/token.go
@@ -3,18 +3,24 @@ package helper
 import (
 	"crypto/rand"
 	"errors"
-	logger "log/slog"
+	"fmt"
 	"math/big"
 )
 
-// GenerateSecureToken generates a cryptographically secure random token
-func GenerateSecureToken(length int) string {
+// GenerateSecureToken generates a cryptographically secure random token of the
+// given length.
+//
+// The error must be handled: every caller uses the result as a secret, and on
+// failure CryptoRandomString yields "" rather than a short token. Returning the
+// error instead of logging it keeps a dead entropy source from silently
+// producing empty passwords, cookies and confirmation tokens.
+func GenerateSecureToken(length int) (string, error) {
 	str, err := CryptoRandomString(int64(length))
 	if err != nil {
-		logger.Error("failed to generate secure token: ", "error", err)
+		return "", fmt.Errorf("failed to generate secure token: %w", err)
 	}
 
-	return str
+	return str, nil
 }
 
 // CryptoRandomInt returns a crypto random integer between 0 and limit, inclusive

--- a/internal/helper/token_test.go
+++ b/internal/helper/token_test.go
@@ -9,16 +9,28 @@ import (
 
 func TestGenerateSecureToken(t *testing.T) {
 	length := 16
-	token1 := GenerateSecureToken(length)
-	token2 := GenerateSecureToken(length)
+	token1, err1 := GenerateSecureToken(length)
+	token2, err2 := GenerateSecureToken(length)
 
+	assert.NoError(t, err1, "GenerateSecureToken should not return an error")
 	assert.Equal(t, length, len(token1), "Token should have the specified length")
 	assert.NotEmpty(t, token1, "Token should not be empty")
 
+	assert.NoError(t, err2, "Second call to GenerateSecureToken should not return an error")
 	assert.Equal(t, length, len(token2), "Second token should also have the specified length")
 	assert.NotEmpty(t, token2, "Second token should not be empty")
 
 	assert.NotEqual(t, token1, token2, "Consecutively generated tokens should be different")
+}
+
+// A negative length reaches make([]byte, length) in CryptoRandomString and
+// panics, so it is not a usable error case here; length 0 is the only input
+// that exercises the non-happy path without a panic.
+func TestGenerateSecureTokenZeroLength(t *testing.T) {
+	token, err := GenerateSecureToken(0)
+
+	assert.NoError(t, err, "zero length should not error")
+	assert.Empty(t, token, "zero length should produce an empty token")
 }
 
 func TestCryptoRandomInt(t *testing.T) {


### PR DESCRIPTION
GenerateSecureToken logged its error and returned the value anyway:

    func GenerateSecureToken(length int) string {
        str, err := CryptoRandomString(int64(length))
        if err != nil {
            logger.Error("failed to generate secure token: ", "error", err)
        }
        return str
    }

CryptoRandomString returns ("", err) on any failure -- it fills a buffer
of the full length and bails on the first CryptoRandomInt error -- so a
dead entropy source yields an empty string, not a short one. Callers
treated that "" as a valid secret:

- RequestManagerChange stored Crc: "" and emailed a confirmation URL
  with an empty ?token=, then returned 201. The request was permanently
  unconfirmable and nothing said so. The only signal was an unrelated
  panic on confirmationToken[:8] further down, removed on another branch.

- generateSingleBackupCode already returned (string, error) but always
  returned nil, so a failure produced the backup code "-" for the user
  to write down.

- UserRegister stored an empty activation cookie and mailed an
  activation link that could never work.

- CreateToken (reset manager) inferred the failure from an
  "if token == ''" check instead of a real error.

Change GenerateSecureToken to return (string, error) and handle it at
all four call sites: the two controllers return 500 rather than
reporting success for an account or request nobody can ever activate,
and the reset manager propagates the real cause.

Keep an explicit empty-token guard in CreateToken. The error return
covers a crypto/rand failure, but GenerateSecureToken(0) returns
("", nil) -- a non-positive TokenLength (misconfiguration) still yields
an empty token with no error, and an empty reset token must never be
stored.

Tests: cover GenerateSecureToken's zero-length case, and add a
CreateToken subtest asserting a zero TokenLength is rejected before any
token row is created. Negative lengths are not tested: they reach
make([]byte, length) in CryptoRandomString and panic before any error
can be returned, a separate pre-existing issue.
