### PR TITLE
fix: guard refresh token claim extraction against panic

### DIFF
--- a/controllers/authentication.go
+++ b/controllers/authentication.go
@@ -358,8 +358,23 @@ func (ctr *AuthenticationController) RefreshToken(c echo.Context) error {
 	claims, err := helper.GetClaimsFromRefreshToken(refreshToken)
 
 	if err == nil {
-		refreshUUID := claims["refresh_uuid"].(string)
-		userID := int32(claims["user_id"].(float64))
+		// Guard the claim extractions: a token that passes signature
+		// verification but is missing / has the wrong type on
+		// refresh_uuid or user_id (e.g. a token from a different
+		// issuer that happens to share the signing key, or one issued
+		// by an older schema) would panic here without these checks
+		// and only be caught by middleware.Recover as a 500.
+		refreshUUID, ok := claims["refresh_uuid"].(string)
+		if !ok || refreshUUID == "" {
+			logger.Warn("Refresh token missing refresh_uuid claim")
+			return apierrors.HandleUnauthorizedError(c, "Invalid refresh token")
+		}
+		userIDFloat, ok := claims["user_id"].(float64)
+		if !ok {
+			logger.Warn("Refresh token missing user_id claim")
+			return apierrors.HandleUnauthorizedError(c, "Invalid refresh token")
+		}
+		userID := int32(userIDFloat)
 
 		user, terr := ctr.s.GetUser(ctx, models.GetUserParams{
 			ID: userID,

--- a/controllers/authentication_test.go
+++ b/controllers/authentication_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/undernetirc/cservice-api/db/mocks"
 	"github.com/undernetirc/cservice-api/db/types/flags"
@@ -1335,6 +1336,64 @@ func TestAuthenticationController_RefreshToken(t *testing.T) {
 		assert.NoError(t, dec.Decode(&cErr), "error decoding")
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.Equal(t, "Invalid or missing refresh token", cErr.Error.Message)
+	})
+
+	// Regression: a refresh token that passes signature verification but
+	// is missing / has the wrong type on either the refresh_uuid or
+	// user_id claim used to panic on an unchecked type assertion, which
+	// middleware.Recover surfaced as a 500 rather than the intended 401.
+	t.Run("malformed refresh token claims should return 401", func(t *testing.T) {
+		makeToken := func(t *testing.T, claims jwt.MapClaims) string {
+			t.Helper()
+			claims["exp"] = time.Now().Add(time.Hour).Unix()
+			tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+			signed, err := tok.SignedString([]byte(config.ServiceJWTRefreshSigningSecret.GetString()))
+			require.NoError(t, err)
+			return signed
+		}
+		cases := []struct {
+			name   string
+			claims jwt.MapClaims
+		}{
+			{
+				name:   "missing refresh_uuid",
+				claims: jwt.MapClaims{"user_id": float64(1)},
+			},
+			{
+				name:   "missing user_id",
+				claims: jwt.MapClaims{"refresh_uuid": "abc-123"},
+			},
+			{
+				name:   "refresh_uuid wrong type",
+				claims: jwt.MapClaims{"refresh_uuid": 42, "user_id": float64(1)},
+			},
+			{
+				name:   "user_id wrong type",
+				claims: jwt.MapClaims{"refresh_uuid": "abc-123", "user_id": "not-a-number"},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				db := mocks.NewQuerier(t)
+				rdb, _ := redismock.NewClientMock()
+				authController := NewAuthenticationController(db, rdb, nil)
+
+				e := echo.New()
+				e.Validator = helper.NewValidator()
+				e.POST("/token/refresh", authController.RefreshToken)
+
+				w := httptest.NewRecorder()
+				r, _ := http.NewRequest("POST", "/token/refresh", nil)
+				r.Header.Add("Content-Type", "application/json")
+				r.Header.Add("Cookie", "refresh_token="+makeToken(t, tc.claims))
+
+				e.ServeHTTP(w, r)
+				resp := w.Result()
+
+				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+				assert.Contains(t, w.Body.String(), "Invalid refresh token")
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
controllers/authentication.go:361-362 read the refresh_uuid and user_id
claims from a validated refresh token via unchecked type assertions:

    refreshUUID := claims["refresh_uuid"].(string)
    userID := int32(claims["user_id"].(float64))

A refresh token that passes signature verification but is missing
either claim, or carries the wrong type on either claim, panics on
the type assertion. middleware.Recover translates the panic into an
HTTP 500 rather than the intended 401 -- same class of bug as the
ConfirmManagerChange token slicing fix.

Reachable scenarios:
- A legitimate refresh token issued by an older schema of the API.
- A JWT from a different service that happens to share the refresh
  signing key.
- Any operator-crafted token used during debugging or migration.

Replace the assertions with ", ok" checks that return a clean 401
("Invalid refresh token") and log a warning naming the missing/wrong
claim, so operators see the real reason in logs instead of a
recovered panic stack.

Add TestAuthenticationController_RefreshToken/malformed_refresh_token_
claims_should_return_401 with four subtests (missing refresh_uuid,
missing user_id, refresh_uuid wrong type, user_id wrong type). Each
signs a well-formed token with the real refresh secret and asserts
401 + "Invalid refresh token" body -- the pre-fix code would surface
these as 500s.
