### PR TITLE
fix: guard RequestManagerChange token logging against an empty token

### DIFF
--- a/controllers/channel.go
+++ b/controllers/channel.go
@@ -1560,7 +1560,7 @@ func (ctr *ChannelController) RequestManagerChange(c echo.Context) error {
 		"channelID", channelID,
 		"newManager", req.NewManagerUsername,
 		"changeType", req.ChangeType,
-		"token", confirmationToken[:8]+"...") // Log only first 8 chars for security
+		"token", confirmationToken[:min(len(confirmationToken), 8)]+"...") // Log only first 8 chars for security
 
 	return c.JSON(http.StatusCreated, response)
 }


### PR DESCRIPTION
RequestManagerChange logs the confirmation token as
confirmationToken[:8]+"...". On master, GenerateSecureToken swallows a
crypto/rand failure and returns "", so confirmationToken can be empty
and ""[:8] panics -- a live path, however rare. Guard it with
confirmationToken[:min(len(confirmationToken), 8)], matching the guard
applied to the user-supplied token in ConfirmManagerChange.

The guard is kept even though it is not the root fix: once
GenerateSecureToken propagates its error (companion PR, which should
merge first), the handler returns 500 before this line and the token is
guaranteed non-empty. The guard then costs nothing and future-proofs the
log line against a change in the token source.

Caveat left as-is: the "..." suffix is unconditional, so an empty token
logs just "..." (harmless -- it leaks nothing). Collapsing all six
copies of this masking expression into a shared helper is the right
cleanup but is out of scope here.
