### PR TITLE
refactor: extract Migrator interface and un-skip migration handler tests

### DIFF
--- a/cmd/cservice-api/main.go
+++ b/cmd/cservice-api/main.go
@@ -212,15 +212,26 @@ func runMigrations() {
 	}
 
 	if migrateUpOne {
-		mgrHandler.MigrationStep(1)
+		ver, err := mgrHandler.MigrationStep(1)
+		if err != nil {
+			globals.LogAndExit(err.Error(), 1)
+		}
+		globals.LogAndExit(fmt.Sprintf("successfully ran migration up to version %d", ver), 0)
 	}
 
 	if migrateDownOne {
-		mgrHandler.MigrationStep(-1)
+		ver, err := mgrHandler.MigrationStep(-1)
+		if err != nil {
+			globals.LogAndExit(err.Error(), 1)
+		}
+		globals.LogAndExit(fmt.Sprintf("successfully ran migration down to version %d", ver), 0)
 	}
 
 	if forceMigration > 0 {
-		mgrHandler.ForceVersion(forceMigration)
+		if err := mgrHandler.ForceVersion(forceMigration); err != nil {
+			globals.LogAndExit(err.Error(), 1)
+		}
+		globals.LogAndExit(fmt.Sprintf("Database migration successful, forced to version %d", forceMigration), 0)
 	}
 
 	// Run db migrations

--- a/db/migration.go
+++ b/db/migration.go
@@ -14,16 +14,30 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/labstack/gommon/log"
 	"github.com/undernetirc/cservice-api/internal/config"
-	"github.com/undernetirc/cservice-api/internal/globals"
 )
 
 //go:embed migrations/*.sql
 var migrationFS embed.FS
 
-type MigrationHandler struct {
-	*migrate.Migrate
+// Migrator is the subset of *migrate.Migrate that MigrationHandler uses.
+// Extracted as an interface so tests can substitute a fake without needing
+// a live database connection.
+type Migrator interface {
+	Steps(n int) error
+	Version() (version uint, dirty bool, err error)
+	Up() error
+	Force(version int) error
 }
 
+// MigrationHandler wraps a Migrator and layers on the project-specific
+// migration workflows (single-step, apply-all, force-version).
+type MigrationHandler struct {
+	m Migrator
+}
+
+// NewMigrationHandler builds a MigrationHandler backed by a real
+// *migrate.Migrate reading the embedded migrations and the DB URI from
+// config.
 func NewMigrationHandler() (*MigrationHandler, error) {
 	d, err := iofs.New(&migrationFS, "migrations")
 	if err != nil {
@@ -34,49 +48,56 @@ func NewMigrationHandler() (*MigrationHandler, error) {
 		return nil, err
 	}
 
-	return &MigrationHandler{m}, nil
+	return &MigrationHandler{m: m}, nil
 }
 
-func (m *MigrationHandler) MigrationStep(step int) {
-	var msg string
-	if step > 0 {
-		msg = "up"
-	} else {
-		msg = "down"
-	}
+// NewMigrationHandlerWith wraps an arbitrary Migrator (typically a test
+// double) so callers can exercise MigrationHandler without touching a real
+// database.
+func NewMigrationHandlerWith(m Migrator) *MigrationHandler {
+	return &MigrationHandler{m: m}
+}
 
-	if err := m.Steps(step); err != nil {
-		globals.LogAndExit(fmt.Sprintf("failed to run migration %s: %s", msg, err), 1)
+// MigrationStep applies `step` migrations (step > 0 = up, step < 0 = down)
+// and returns the resulting schema version on success. Callers own the
+// log/exit decision so the library can be tested without process termination.
+func (h *MigrationHandler) MigrationStep(step int) (uint, error) {
+	if err := h.m.Steps(step); err != nil {
+		direction := "up"
+		if step < 0 {
+			direction = "down"
+		}
+		return 0, fmt.Errorf("failed to run migration %s: %w", direction, err)
 	}
-	ver, _, err := m.Version()
+	ver, _, err := h.m.Version()
 	if err != nil {
-		globals.LogAndExit(err.Error(), 1)
+		return 0, err
 	}
-	globals.LogAndExit(fmt.Sprintf("successfully ran migration %s to version %d", msg, ver), 0)
+	return ver, nil
 }
 
-func (m *MigrationHandler) RunMigrations() error {
+// RunMigrations applies all pending migrations. golang-migrate reports a
+// no-op run via a "no change" error, which is treated as success here.
+func (h *MigrationHandler) RunMigrations() error {
 	log.Info("Running database migrations")
-	if err := m.Up(); err != nil {
+	if err := h.m.Up(); err != nil {
 		if strings.Contains(err.Error(), "no change") {
 			log.Info("Database migration: NO CHANGE")
-		} else {
-			return err
+			return nil
 		}
-	} else {
-		log.Info("Database migration: SUCCESS")
+		return err
 	}
+	log.Info("Database migration: SUCCESS")
 	return nil
 }
 
-func (m *MigrationHandler) ForceVersion(version int) {
-	if err := m.Force(version); err != nil {
-		globals.LogAndExit(err.Error(), 1)
-	}
-	globals.LogAndExit(fmt.Sprint("Database migration successful, forced to version ", version), 0)
+// ForceVersion sets the schema version, bypassing dirty-state checks.
+// Callers own the log/exit decision.
+func (h *MigrationHandler) ForceVersion(version int) error {
+	return h.m.Force(version)
 }
 
-// ListMigrations returns a list of all migration files
+// ListMigrations returns a list of all migration files.
 func ListMigrations() ([]string, error) {
 	var files []string
 	if err := fs.WalkDir(&migrationFS, ".", func(path string, d fs.DirEntry, _ error) error {
@@ -91,6 +112,7 @@ func ListMigrations() ([]string, error) {
 	return files, nil
 }
 
+// ViewMigration returns the raw contents of a single migration file.
 func ViewMigration(file string) []byte {
 	f, _ := migrationFS.ReadFile(file)
 	return f

--- a/db/migration_test.go
+++ b/db/migration_test.go
@@ -4,9 +4,11 @@
 package db
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestViewMigration tests the ViewMigration function
@@ -44,25 +46,184 @@ func TestViewMigration(t *testing.T) {
 	}
 }
 
-// TestMigrationHandler_Step tests the MigrationStep method
+// mockMigrator is a hand-rolled test double for the Migrator interface.
+// Fields capture the last invocation for assertion; *Err fields let a test
+// force a specific failure path.
+type mockMigrator struct {
+	stepsCalledWith int
+	stepsErr        error
+	upCalled        bool
+	upErr           error
+	forceCalledWith int
+	forceErr        error
+	versionResult   uint
+	versionErr      error
+}
+
+func (m *mockMigrator) Steps(n int) error {
+	m.stepsCalledWith = n
+	return m.stepsErr
+}
+
+func (m *mockMigrator) Version() (uint, bool, error) {
+	return m.versionResult, false, m.versionErr
+}
+
+func (m *mockMigrator) Up() error {
+	m.upCalled = true
+	return m.upErr
+}
+
+func (m *mockMigrator) Force(v int) error {
+	m.forceCalledWith = v
+	return m.forceErr
+}
+
+// TestMigrationHandler_Step covers MigrationStep against a mock Migrator so
+// the success + failure paths (Steps error, Version error) can be verified
+// without a live database.
 func TestMigrationHandler_Step(t *testing.T) {
-	// This test is skipped because it requires mocking the migrate.Migrate interface
-	// which is difficult to do without modifying the original code
-	t.Skip("TestMigrationHandler_Step requires mocking the migrate.Migrate interface")
+	tests := []struct {
+		name            string
+		step            int
+		stepsErr        error
+		versionResult   uint
+		versionErr      error
+		wantErr         bool
+		wantVersion     uint
+		wantErrContains string
+	}{
+		{
+			name:          "up one succeeds",
+			step:          1,
+			versionResult: 3,
+			wantVersion:   3,
+		},
+		{
+			name:          "down one succeeds",
+			step:          -1,
+			versionResult: 2,
+			wantVersion:   2,
+		},
+		{
+			name:            "steps failure wraps direction",
+			step:            1,
+			stepsErr:        errors.New("boom"),
+			wantErr:         true,
+			wantErrContains: "up",
+		},
+		{
+			name:            "steps failure wraps direction (down)",
+			step:            -1,
+			stepsErr:        errors.New("boom"),
+			wantErr:         true,
+			wantErrContains: "down",
+		},
+		{
+			name:       "version query failure surfaces",
+			step:       1,
+			versionErr: errors.New("no version"),
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockMigrator{
+				stepsErr:      tt.stepsErr,
+				versionResult: tt.versionResult,
+				versionErr:    tt.versionErr,
+			}
+			h := NewMigrationHandlerWith(m)
+
+			ver, err := h.MigrationStep(tt.step)
+
+			assert.Equal(t, tt.step, m.stepsCalledWith)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVersion, ver)
+		})
+	}
 }
 
-// TestMigrationHandler_RunMigrations tests the RunMigrations method
+// TestMigrationHandler_RunMigrations covers RunMigrations, including
+// golang-migrate's "no change" convention which must be treated as success.
 func TestMigrationHandler_RunMigrations(t *testing.T) {
-	// This test is skipped because it requires mocking the migrate.Migrate interface
-	// which is difficult to do without modifying the original code
-	t.Skip("TestMigrationHandler_RunMigrations requires mocking the migrate.Migrate interface")
+	tests := []struct {
+		name    string
+		upErr   error
+		wantErr bool
+	}{
+		{
+			name: "clean apply succeeds",
+		},
+		{
+			name:  "no-change is not an error",
+			upErr: errors.New("no change"),
+		},
+		{
+			name:    "other error propagates",
+			upErr:   errors.New("boom"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockMigrator{upErr: tt.upErr}
+			h := NewMigrationHandlerWith(m)
+
+			err := h.RunMigrations()
+
+			assert.True(t, m.upCalled)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-// TestNewMigrationHandler tests the NewMigrationHandler function
-func TestNewMigrationHandler(t *testing.T) {
-	// This test is skipped because it requires a real database connection
-	// which is difficult to set up in a test environment
-	t.Skip("TestNewMigrationHandler requires a real database connection")
+// TestMigrationHandler_ForceVersion covers ForceVersion in both the happy
+// and failing paths against a mock Migrator.
+func TestMigrationHandler_ForceVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  int
+		forceErr error
+		wantErr  bool
+	}{
+		{
+			name:    "forces requested version",
+			version: 42,
+		},
+		{
+			name:     "surfaces forcing error",
+			version:  7,
+			forceErr: errors.New("boom"),
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockMigrator{forceErr: tt.forceErr}
+			h := NewMigrationHandlerWith(m)
+
+			err := h.ForceVersion(tt.version)
+
+			assert.Equal(t, tt.version, m.forceCalledWith)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 // TestListMigrations tests the ListMigrations function


### PR DESCRIPTION
db/migration_test.go had three tests disabled with skips explaining
they needed a mockable migrate.Migrate or a real database:
- TestMigrationHandler_Step
- TestMigrationHandler_RunMigrations
- TestNewMigrationHandler (empty body, just a placeholder)

The blocker was that MigrationHandler embedded *migrate.Migrate
directly and MigrationStep / ForceVersion called globals.LogAndExit
on both success and failure — so callers could not observe outcomes
and tests could not run in-process.

Refactor:

- db/migration.go
  - Introduce a Migrator interface (Steps, Version, Up, Force) that
    captures the subset of *migrate.Migrate MigrationHandler uses.
  - Replace the *migrate.Migrate embedding with a Migrator field.
  - Add NewMigrationHandlerWith(m Migrator) for test injection.
  - MigrationStep now returns (uint, error); ForceVersion returns
    error. Neither calls LogAndExit — that decision belongs to the
    CLI layer, not the library.
  - RunMigrations still returns error (unchanged shape); implementation
    routes through the new interface field.

- cmd/cservice-api/main.go
  - runMigrations now handles the errors from MigrationStep and
    ForceVersion, calling globals.LogAndExit with the same messages
    that previously lived in the library.

- db/migration_test.go
  - Add a hand-rolled mockMigrator (no mockery / no external mock
    library) that records last-call args and returns configurable
    errors.
  - Un-skip TestMigrationHandler_Step with a table covering up-one,
    down-one, Steps failure (asserts the wrapped error mentions the
    direction), and Version failure.
  - Un-skip TestMigrationHandler_RunMigrations with a table covering
    clean apply, the "no change" success convention, and other-error
    propagation.
  - Add TestMigrationHandler_ForceVersion covering happy path and
    error propagation.
  - Delete the placeholder TestNewMigrationHandler (empty body, only a
    t.Skip — was dead scaffolding, not a test).

Breaking API changes on the exported MigrationHandler:
- MigrationStep(int) → MigrationStep(int) (uint, error)
- ForceVersion(int) → ForceVersion(int) error
Only main.go consumed these; caller updated in the same commit. The
project is pre-1.0 (README: "WORK IN PROGRESS ... DO NOT USE IN
PRODUCTION") so this is an acceptable break.

Net effect: three previously-unreachable code paths in MigrationHandler
now have real unit test coverage without needing a live Postgres.
