### PR TITLE
refactor: remove dead instrumented cron scheduler block in main

### DIFF
--- a/cmd/cservice-api/main.go
+++ b/cmd/cservice-api/main.go
@@ -395,26 +395,6 @@ func run() error {
 	}
 	shutdownManager.cronService = cronService
 
-	// Replace cron scheduler with instrumented version if system metrics are available
-	if systemMetrics != nil && cronService.IsEnabled() {
-		// Create instrumented cron scheduler
-		schedulerConfig := cron.Config{
-			PasswordResetCleanupCron: cronConfig.PasswordResetCleanupCron,
-			TimeZone:                 cronConfig.TimeZone,
-		}
-
-		instrumentedScheduler, err := cron.NewInstrumentedScheduler(schedulerConfig, logger, systemMetrics)
-		if err != nil {
-			logger.Error("failed to create instrumented cron scheduler", "error", err)
-			return err
-		}
-
-		// Note: We would need to modify the cron.Service to accept an instrumented scheduler
-		// For now, we'll just log that we have the capability
-		logger.Info("Instrumented cron scheduler created (integration pending)")
-		_ = instrumentedScheduler // Prevent unused variable error
-	}
-
 	// Setup password reset cleanup job if cron service is enabled
 	if cronService.IsEnabled() {
 		if err := cronService.SetupPasswordResetCleanup(db, cronConfig); err != nil {


### PR DESCRIPTION
The block at cmd/cservice-api/main.go:398-416 created an
InstrumentedScheduler and immediately discarded it via
_ = instrumentedScheduler with an inline comment saying "Prevent
unused variable error". The preceding log line ("Instrumented cron
scheduler created (integration pending)") and the block comment
("We would need to modify the cron.Service to accept an
instrumented scheduler") both acknowledged the block does nothing
useful.

Users were getting the non-instrumented scheduler either way (via
cronService.SetupPasswordResetCleanup a few lines below), so the
block was a misleading no-op that hinted at capabilities the service
does not actually provide.

Delete the block. If genuine instrumentation integration is desired
later, it should be added by wiring an instrumented scheduler into
cron.Service.SetupPasswordResetCleanup, not by re-adding dead
scaffolding here.

