### PR TITLE
test: un-skip TestRealPasswordResetCleanup scheduler registration test

### DIFF
--- a/internal/cron/cron_test.go
+++ b/internal/cron/cron_test.go
@@ -306,17 +306,16 @@ func TestPasswordResetCleanupJobExecution(t *testing.T) {
 	})
 }
 
-// TestRealPasswordResetCleanup tests with actual reset components
-// This test is more of an integration test
+// TestRealPasswordResetCleanup verifies the scheduler can be wired with
+// real reset components and registers the cleanup job. The test never
+// triggers the cron entry so the nil Querier held by the token manager
+// is not dereferenced; job execution against a real database is out of
+// scope here (and would belong in integration/).
 func TestRealPasswordResetCleanup(t *testing.T) {
-	// Skip this test unless we have a real database connection
-	t.Skip("Integration test - requires database setup")
-
 	logger := createTestLogger()
 	scheduler, err := NewScheduler(DefaultConfig(), logger)
 	require.NoError(t, err)
 
-	// This would require actual database setup
 	var queries models.Querier
 	tokenManager := reset.NewTokenManager(queries, nil)
 	cleanupService := reset.NewCleanupService(tokenManager, 1*time.Hour, logger)


### PR DESCRIPTION
internal/cron/cron_test.go:313 had TestRealPasswordResetCleanup
disabled with t.Skip("Integration test - requires database setup").
The skip was a false negative — the test only exercises the
scheduler's job-registration path (AddPasswordResetCleanupJob +
GetEntries) and never triggers the cron entry, so the nil Querier
held by the reset.TokenManager is never dereferenced. No database is
actually required.

The reset.NewTokenManager and reset.NewCleanupService constructors
are both nil-safe for the code paths this test exercises, so the
existing body works as-is once the unconditional skip is removed.

Refresh the doc comment to explain the scope (registration only,
not execution) so a future reader does not re-add the skip.
