### PR TITLE
test: un-skip HealthCheckRoutes with nil-pool guard coverage

### DIFF
--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -257,11 +257,43 @@ func TestRouteServiceMethods(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, rec.Code) // Should be bad request due to missing JWT token
 	})
 
-	// Test HealthCheckRoutes
-	t.Run("HealthCheckRoutes", func(t *testing.T) {
-		// Skip the health check test for now as it requires a properly initialized pool
-		t.Skip("Health check test requires a properly initialized pool")
-	})
+	// Test HealthCheckRoutes — verifies the nil-pool guard behavior. When
+	// pool is nil the route must not be registered (safe default when the
+	// service starts without a working DB connection); when pool is non-nil
+	// the route must be registered. We assert route registration only, not
+	// the handler behavior (which is exercised by controllers/health_check_test.go).
+	healthChecks := []struct {
+		name              string
+		pool              *pgxpool.Pool
+		wantRouteRegister bool
+	}{
+		{
+			name:              "nil pool: route is not registered",
+			pool:              nil,
+			wantRouteRegister: false,
+		},
+		{
+			name:              "non-nil pool: route is registered",
+			pool:              &pgxpool.Pool{},
+			wantRouteRegister: true,
+		},
+	}
+	for _, tt := range healthChecks {
+		t.Run("HealthCheckRoutes/"+tt.name, func(t *testing.T) {
+			ee := echo.New()
+			rrs := NewRouteService(ee, mocks.NewServiceInterface(t), tt.pool, redis.NewClient(&redis.Options{}))
+			rrs.HealthCheckRoutes()
+
+			found := false
+			for _, route := range ee.Routes() {
+				if route.Path == "/health-check" && route.Method == http.MethodGet {
+					found = true
+					break
+				}
+			}
+			assert.Equal(t, tt.wantRouteRegister, found)
+		})
+	}
 }
 
 func TestRouteServiceContext(t *testing.T) {


### PR DESCRIPTION
routes/routes_test.go:263 had TestRouteServiceMethods/HealthCheckRoutes
disabled with t.Skip("Health check test requires a properly
initialized pool"). The skip was overcautious — HealthCheckRoutes
itself only decides whether to register the /health-check route
(if r.pool != nil ...); it does not exercise the pool. Registration
can be verified without a working DB.

Replace the skip stub with a struct-table subtest covering both
branches of the guard:

- nil pool → /health-check must NOT be registered (safe default when
  the service starts without a working DB)
- non-nil pool → /health-check MUST be registered

Each case builds a fresh RouteService and calls HealthCheckRoutes(),
then asserts on ee.Routes(). Handler behavior itself is exercised
by controllers/health_check_test.go and is out of scope here.
