### PR TITLE
test: complete manager change end-to-end workflow with confirmation

### DIFF
--- a/integration/manager_change_test.go
+++ b/integration/manager_change_test.go
@@ -255,15 +255,56 @@ func TestManagerChange_EndToEndWorkflow(t *testing.T) {
 		assert.Equal(t, "temporary", *statusResp.ChangeType)
 		assert.Equal(t, newManagerUsername, *statusResp.NewManager)
 
-		// Step 4: Get confirmation token and confirm the request
-		// Skipping confirmation step due to panic in ConfirmManagerChange function
-		// This would normally test the email confirmation workflow
-		t.Log("Skipping confirmation step - panic in ConfirmManagerChange needs separate fix")
+		// Step 4: Fetch the confirmation token from the DB (mailpit gives us
+		// the message but parsing the HTML for the token is fragile) and
+		// drive the /manager-confirm endpoint. Previously blocked by a
+		// panic on short tokens in ConfirmManagerChange, now safe to run.
+		var token string
+		err = dbPool.QueryRow(
+			ctx,
+			"SELECT crc FROM pending_mgrchange WHERE channel_id = $1 ORDER BY id DESC LIMIT 1",
+			channelID,
+		).Scan(&token)
+		require.NoError(t, err)
+		require.NotEmpty(t, token, "confirmation token should have been written to pending_mgrchange")
 
-		// The test successfully verified:
-		// 1. Manager change request creation
-		// 2. Email sending
-		// 3. Status endpoint returns pending request correctly
+		w3 := httptest.NewRecorder()
+		r3, _ := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/channels/%d/manager-confirm?token=%s", channelID, token),
+			nil,
+		)
+
+		c3 := e.NewContext(r3, w3)
+		c3.SetParamNames("id")
+		c3.SetParamValues(strconv.Itoa(int(channelID)))
+		c3.Set("user", claims)
+
+		err = controller.ConfirmManagerChange(c3)
+		require.NoError(t, err)
+
+		resp3 := w3.Result()
+		require.Equal(t, http.StatusOK, resp3.StatusCode)
+
+		var confirmResp controllers.ManagerChangeConfirmationResponse
+		dec = json.NewDecoder(resp3.Body)
+		err = dec.Decode(&confirmResp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "success", confirmResp.Status)
+		assert.Equal(t, "confirmed", confirmResp.Data.Status)
+		assert.Equal(t, channelID, confirmResp.Data.ChannelID)
+		assert.Equal(t, "temporary", confirmResp.Data.ChangeType)
+
+		// Step 5: The pending_mgrchange row should now be marked confirmed=1.
+		var confirmed string
+		err = dbPool.QueryRow(
+			ctx,
+			"SELECT confirmed FROM pending_mgrchange WHERE crc = $1",
+			token,
+		).Scan(&confirmed)
+		require.NoError(t, err)
+		assert.Equal(t, "1", confirmed)
 	})
 }
 


### PR DESCRIPTION
TestManagerChange_EndToEndWorkflow/complete_manager_change_workflow
verified steps 1-3 (request creation, email delivery via mailpit,
status endpoint) and then stopped at step 4 with:

    t.Log("Skipping confirmation step - panic in ConfirmManagerChange
    needs separate fix")

The referenced panic is unrelated to this workflow — server-generated
tokens are always long enough to slice safely — so the workflow can
be completed without waiting on that fix.

Extend the test with steps 4 and 5:

- Step 4: read the confirmation token directly from pending_mgrchange
  via dbPool.QueryRow (parsing it out of the mailpit HTML would be
  fragile), then drive GET /channels/:id/manager-confirm?token=... and
  assert 200 + status=confirmed + change_type=temporary in the
  response body.
- Step 5: verify the DB row's confirmed column is now '1'.

Net effect: the manager-change happy path is now covered end-to-end
against a real Postgres + real mailpit, closing the loop from
submission through email delivery to confirmation.
