### PR TITLE
feat: make Postgres sslmode and TLS material configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,21 @@ export CSERVICE_DATABASE_PORT=5432
 export CSERVICE_DATABASE_USERNAME=cservice
 export CSERVICE_DATABASE_PASSWORD=cservice
 export CSERVICE_DATABASE_NAME=cservice
+
+# Database TLS (optional; sslmode defaults to "disable")
+export CSERVICE_DATABASE_SSL_MODE=disable
+export CSERVICE_DATABASE_SSL_ROOT_CERT=/etc/ssl/certs/ca.crt
+export CSERVICE_DATABASE_SSL_CERT=/etc/ssl/certs/client.crt
+export CSERVICE_DATABASE_SSL_KEY=/etc/ssl/private/client.key
 ```
+
+`CSERVICE_DATABASE_SSL_MODE` accepts the standard libpq modes: `disable`,
+`allow`, `prefer`, `require`, `verify-ca`, and `verify-full`. Note that
+`require` encrypts the connection but does **not** verify the server
+certificate, so it does not protect against an active man-in-the-middle;
+use `verify-full` when the server's certificate chain is available. The
+three cert paths are optional and only consulted for `require` and
+stricter modes.
 
 ### JWT Configuration
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -190,6 +190,12 @@ database:
   password: "cservice"
   name: "cservice"
   auto_migration: true
+  # libpq sslmode: disable, allow, prefer, require, verify-ca, verify-full (default: disable)
+  ssl_mode: "disable"
+  # Optional TLS material paths (used with sslmode of require or stricter)
+  ssl_root_cert: ""
+  ssl_cert: ""
+  ssl_key: ""
 
 # Redis config
 redis:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -108,6 +109,14 @@ const (
 	DatabaseName K = `database.name`
 	// DatabaseAutoMigration is whether to automatically apply the migrations to the database
 	DatabaseAutoMigration K = `database.auto_migration`
+	// DatabaseSSLMode is the libpq sslmode (disable, allow, prefer, require, verify-ca, verify-full)
+	DatabaseSSLMode K = `database.ssl_mode`
+	// DatabaseSSLRootCert is the path to the SSL CA certificate file (optional)
+	DatabaseSSLRootCert K = `database.ssl_root_cert`
+	// DatabaseSSLCert is the path to the client SSL certificate file (optional)
+	DatabaseSSLCert K = `database.ssl_cert`
+	// DatabaseSSLKey is the path to the client SSL private key file (optional)
+	DatabaseSSLKey K = `database.ssl_key`
 
 	// RedisHost is the host to connect to the redis
 	RedisHost K = `redis.host`
@@ -323,6 +332,7 @@ func DefaultConfig() {
 	DatabasePassword.setDefault("cservice")
 	DatabaseName.setDefault("cservice")
 	DatabaseAutoMigration.setDefault(true)
+	DatabaseSSLMode.setDefault("disable")
 
 	RedisHost.setDefault("localhost")
 	RedisPort.setDefault(6379)
@@ -439,16 +449,30 @@ func InitConfig(configFile string) {
 	}
 }
 
-// GetDbURI returns a database connection string
+// GetDbURI returns a database connection string.
+// sslmode defaults to "disable"; when configured, optional client/CA cert paths
+// are appended so libpq/pgx can locate them.
 func GetDbURI() string {
-	// TODO: add SSL configuration support
+	params := url.Values{}
+	params.Set("sslmode", DatabaseSSLMode.GetString())
+	if v := DatabaseSSLRootCert.GetString(); v != "" {
+		params.Set("sslrootcert", v)
+	}
+	if v := DatabaseSSLCert.GetString(); v != "" {
+		params.Set("sslcert", v)
+	}
+	if v := DatabaseSSLKey.GetString(); v != "" {
+		params.Set("sslkey", v)
+	}
+
 	return fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		"postgres://%s:%s@%s:%s/%s?%s",
 		DatabaseUsername.GetString(),
 		DatabasePassword.GetString(),
 		DatabaseHost.GetString(),
 		DatabasePort.GetString(),
 		DatabaseName.GetString(),
+		params.Encode(),
 	)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"strings"
 
@@ -465,15 +466,19 @@ func GetDbURI() string {
 		params.Set("sslkey", v)
 	}
 
-	return fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?%s",
-		DatabaseUsername.GetString(),
-		DatabasePassword.GetString(),
-		DatabaseHost.GetString(),
-		DatabasePort.GetString(),
-		DatabaseName.GetString(),
-		params.Encode(),
-	)
+	// Build via url.URL rather than fmt.Sprintf so the userinfo is escaped.
+	// pgx parses postgres:// DSNs with url.Parse, which splits the authority
+	// on the first "/" -- an unescaped "/" in the password (base64 secrets
+	// routinely contain one; see the openssl rand -base64 recipe in the
+	// README) truncates the host and surfaces as "invalid port".
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(DatabaseUsername.GetString(), DatabasePassword.GetString()),
+		Host:     net.JoinHostPort(DatabaseHost.GetString(), DatabasePort.GetString()),
+		Path:     "/" + DatabaseName.GetString(),
+		RawQuery: params.Encode(),
+	}
+	return u.String()
 }
 
 // GetServerAddress returns the address string to bind the service to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,22 +145,55 @@ service:
 }
 
 func TestGetDbURI(t *testing.T) {
-	// Reset viper before test
 	viper.Reset()
 
-	// Set test values
 	DatabaseHost.Set("test-host")
 	DatabasePort.Set("5432")
 	DatabaseUsername.Set("test-user")
 	DatabasePassword.Set("test-pass")
 	DatabaseName.Set("test-db")
 
-	// Get the URI
-	uri := GetDbURI()
+	tests := []struct {
+		name        string
+		sslMode     string
+		sslRootCert string
+		sslCert     string
+		sslKey      string
+		want        string
+	}{
+		{
+			name:    "default sslmode disable produces the pre-existing URI byte-for-byte",
+			sslMode: "disable",
+			want:    "postgres://test-user:test-pass@test-host:5432/test-db?sslmode=disable",
+		},
+		{
+			name:        "verify-full with cert material appends URL-encoded paths",
+			sslMode:     "verify-full",
+			sslRootCert: "/etc/ssl/ca.crt",
+			sslCert:     "/etc/ssl/client.crt",
+			sslKey:      "/etc/ssl/client.key",
+			want: "postgres://test-user:test-pass@test-host:5432/test-db?" +
+				"sslcert=%2Fetc%2Fssl%2Fclient.crt&sslkey=%2Fetc%2Fssl%2Fclient.key&" +
+				"sslmode=verify-full&sslrootcert=%2Fetc%2Fssl%2Fca.crt",
+		},
+		{
+			name:        "require with only root cert set omits unset client cert paths",
+			sslMode:     "require",
+			sslRootCert: "/etc/ssl/ca.crt",
+			want: "postgres://test-user:test-pass@test-host:5432/test-db?" +
+				"sslmode=require&sslrootcert=%2Fetc%2Fssl%2Fca.crt",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DatabaseSSLMode.Set(tt.sslMode)
+			DatabaseSSLRootCert.Set(tt.sslRootCert)
+			DatabaseSSLCert.Set(tt.sslCert)
+			DatabaseSSLKey.Set(tt.sslKey)
 
-	// Test the URI format
-	expectedURI := "postgres://test-user:test-pass@test-host:5432/test-db?sslmode=disable"
-	assert.Equal(t, expectedURI, uri)
+			assert.Equal(t, tt.want, GetDbURI())
+		})
+	}
 }
 
 func TestGetServerAddress(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,12 +4,14 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"strconv"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKTypeMethods(t *testing.T) {
@@ -155,6 +157,7 @@ func TestGetDbURI(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		password    string // defaults to "test-pass" when empty
 		sslMode     string
 		sslRootCert string
 		sslCert     string
@@ -165,6 +168,22 @@ func TestGetDbURI(t *testing.T) {
 			name:    "default sslmode disable produces the pre-existing URI byte-for-byte",
 			sslMode: "disable",
 			want:    "postgres://test-user:test-pass@test-host:5432/test-db?sslmode=disable",
+		},
+		{
+			// Regression: "openssl rand -base64 32" (README's recommended
+			// recipe) emits from [A-Za-z0-9+/=], so roughly half of generated
+			// passwords contain a "/". Unescaped, that truncated the authority
+			// and pgx rejected the DSN with "invalid port".
+			name:     "password containing base64 characters is escaped",
+			password: "ab/cd+ef=",
+			sslMode:  "disable",
+			want:     "postgres://test-user:ab%2Fcd+ef=@test-host:5432/test-db?sslmode=disable",
+		},
+		{
+			name:     "password containing URI delimiters is escaped",
+			password: "p@ss:w/rd?#x",
+			sslMode:  "disable",
+			want:     "postgres://test-user:p%40ss%3Aw%2Frd%3F%23x@test-host:5432/test-db?sslmode=disable",
 		},
 		{
 			name:        "verify-full with cert material appends URL-encoded paths",
@@ -186,12 +205,27 @@ func TestGetDbURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			password := tt.password
+			if password == "" {
+				password = "test-pass"
+			}
+			DatabasePassword.Set(password)
 			DatabaseSSLMode.Set(tt.sslMode)
 			DatabaseSSLRootCert.Set(tt.sslRootCert)
 			DatabaseSSLCert.Set(tt.sslCert)
 			DatabaseSSLKey.Set(tt.sslKey)
 
-			assert.Equal(t, tt.want, GetDbURI())
+			got := GetDbURI()
+			assert.Equal(t, tt.want, got)
+
+			// The DSN is only useful if pgx can parse it back; pgx uses
+			// url.Parse for postgres:// URLs.
+			u, err := url.Parse(got)
+			require.NoError(t, err)
+			gotPassword, _ := u.User.Password()
+			assert.Equal(t, password, gotPassword, "password must survive a parse round-trip")
+			assert.Equal(t, "test-host:5432", u.Host)
+			assert.Equal(t, "/test-db", u.Path)
 		})
 	}
 }


### PR DESCRIPTION
Two related changes to `GetDbURI`, as separate commits:

**feat: make Postgres sslmode and TLS material configurable**
`GetDbURI` hardcoded `?sslmode=disable`, so there was no way to run against a TLS-only Postgres. Adds `database.ssl_mode` plus optional `ssl_root_cert` / `ssl_cert` / `ssl_key` (`ssl_mode` defaults to `disable`, so existing deployments are unchanged); cert paths are appended only when set. Documents the `CSERVICE_DATABASE_SSL_*` env vars and `require`'s MITM caveat in the README and `config.yml.example`.

**fix: escape userinfo when building the database DSN**
`GetDbURI` interpolated the username/password raw, so an unescaped `/` in a base64 password (per the README's `openssl rand -base64` recipe) truncated the host under `url.Parse` and broke startup for ~half of generated passwords. Rebuilds the DSN with `url.URL` / `url.UserPassword` / `net.JoinHostPort` (RFC-3986 userinfo escaping, plus IPv6 bracketing). The default DSN is byte-for-byte unchanged.

## Testing
- `TestGetDbURI` covers default (byte-for-byte), verify-full with certs, require + root cert, and base64 / URI-delimiter passwords, each asserting a `url.Parse` round-trip.
- `go build`, `go test`, `go vet`, and `make lint` all pass; both commits build independently.
